### PR TITLE
Update aws-cli Plan Package Version

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -2,6 +2,7 @@ pkg_name=aws-cli
 pkg_origin=core
 pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
 pkg_license=('Apache-2.0')
+pkg_version=1.19.72
 pkg_description="The AWS Command Line Interface (CLI) is a unified tool to \
   manage your AWS services. With just one tool to download and configure, you \
   can control multiple AWS services from the command line and automate them \
@@ -16,11 +17,6 @@ pkg_deps=(
   core/python
 )
 pkg_bin_dirs=(bin)
-
-pkg_version() {
-  export LC_ALL=en_US LANG=en_US
-  pip search --disable-pip-version-check awscli | grep '^awscli (' | awk -F'[()]' '{print $2}'
-}
 
 do_before() {
   update_pkg_version

--- a/plan.sh
+++ b/plan.sh
@@ -18,10 +18,6 @@ pkg_deps=(
 )
 pkg_bin_dirs=(bin)
 
-do_before() {
-  update_pkg_version
-}
-
 do_prepare() {
   python -m venv "$pkg_prefix"
   # shellcheck source=/dev/null


### PR DESCRIPTION
Update pkg_version auto -> 1.19.72 in support of 2021 Q2 core plans refresh.